### PR TITLE
Upgrade to pyo3 ^0.17.0, set version to v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spacy-alignments"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "pyo3",
  "tokenizations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,26 +22,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
-dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
- "unindent",
-]
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "instant"
@@ -59,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -93,31 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,35 +101,48 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.15.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+checksum = "201b6887e5576bf2f945fe65172c1fcbf3fcf285b23e4d71eb171d9736e38d32"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
+ "memoffset",
  "parking_lot",
- "paste",
  "pyo3-build-config",
+ "pyo3-ffi",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.15.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+checksum = "bf0708c9ed01692635cbf056e286008e5a2927ab1a5e48cdd3aeb1ba5a6fef47"
 dependencies = [
  "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90352dea4f486932b72ddf776264d293f85b79a1d214de1d023927b41461132d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.15.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+checksum = "7eb24b804a2d9e88bfcc480a5a6dd76f006c1e3edaf064e8250423336e2cd79d"
 dependencies = [
+ "proc-macro2",
  "pyo3-macros-backend",
  "quote",
  "syn",
@@ -164,12 +150,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.15.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+checksum = "f22bb49f6a7348c253d7ac67a6875f2dc65f36c2ae64a82c381d528972bea6d6"
 dependencies = [
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -212,7 +197,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spacy-alignments"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "pyo3",
  "tokenizations",
@@ -228,6 +213,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spacy-alignments"
-version = "0.8.6"
+version = "0.9.0"
 authors = ["Explosion <contact@explosion.ai>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 tokenizations = "0.4.2"
 
 [dependencies.pyo3]
-version = "^0.15.0"
+version = "^0.17.0"
 features = ["extension-module"]
 
 [lib]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,6 @@ jobs:
 - job: 'Test'
   strategy:
     matrix:
-      Python36Linux:
-        imageName: 'ubuntu-20.04'
-        python.version: '3.6'
       Python37Windows:
         imageName: 'windows-latest'
         python.version: '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Programming Language :: Rust
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -30,7 +29,7 @@ classifiers =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools-rust
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools_rust import RustExtension
 
 setup(
     name="spacy-alignments",
-    version="0.8.6",
+    version="0.9.0",
     packages=["spacy_alignments", "spacy_alignments.tests"],
     rust_extensions=[RustExtension("spacy_alignments.tokenizations")],
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use tokenizations::{get_alignments, get_charmap, Alignment, CharMap};
 #[pymodule]
  #[pyo3(name = "tokenizations")]
 fn tokenizations_(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("__version__", "0.8.6")?;
+    m.add("__version__", "0.9.0")?;
 
     #[pyfn(m)]
     #[pyo3(name = "get_alignments")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use tokenizations::{get_alignments, get_charmap, Alignment, CharMap};
 
 #[pymodule]
- #[pyo3(name = "tokenizations")]
+#[pyo3(name = "tokenizations")]
 fn tokenizations_(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", "0.9.0")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@ use pyo3::prelude::*;
 use tokenizations::{get_alignments, get_charmap, Alignment, CharMap};
 
 #[pymodule]
-fn tokenizations(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("__version__", "0.8.3")?;
+ #[pyo3(name = "tokenizations")]
+fn tokenizations_(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("__version__", "0.8.6")?;
 
-    #[pyfn(m, "get_alignments")]
+    #[pyfn(m)]
+    #[pyo3(name = "get_alignments")]
     pub fn get_alignments_py(
         _py: Python,
         a: Vec<&str>,
@@ -15,7 +17,8 @@ fn tokenizations(_py: Python, m: &PyModule) -> PyResult<()> {
         Ok(get_alignments(&a, &b))
     }
 
-    #[pyfn(m, "get_charmap")]
+    #[pyfn(m)]
+    #[pyo3(name = "get_charmap")]
     pub fn get_charmap_py(_py: Python, a: &str, b: &str) -> PyResult<(CharMap, CharMap)> {
         Ok(get_charmap(a, b))
     }


### PR DESCRIPTION
For improved support of Python 3.11 and PyPy.

Drops Python 3.6.